### PR TITLE
Remove online WAVE

### DIFF
--- a/src/pages/GraceHopper.tsx
+++ b/src/pages/GraceHopper.tsx
@@ -68,7 +68,7 @@ const GraceHopper = (/* props */): ReactElement => (
                 <ExternalLink href='https://wave.webaim.org/extension/'>
                   WAVE browser extension
                 </ExternalLink>
-{/*                 {' '} 
+                {/*                 {' '} 
                 (preferred) . OR Bookmark{' '}
                 <ExternalLink href='https://wave.webaim.org/'>
                   online WAVE evaluator


### PR DESCRIPTION
Remove WAVE website link - it doesn't work with github pages
